### PR TITLE
chore: sync git-policies to public mirror

### DIFF
--- a/claude/git-policies.md
+++ b/claude/git-policies.md
@@ -17,7 +17,8 @@ The workflow:
 
 1. **Spot a bug or issue** → Create a GitHub issue first
    - Use appropriate labels: `bug`, `enhancement`, `documentation`, or other GitHub defaults
-   - Example: `gh issue create --title "Fix auth timeout" --label bug`
+   - Always include `--assignee J-MaFf`
+   - Example: `gh issue create --title "Fix auth timeout" --label bug --assignee J-MaFf`
 
 2. **Create a branch** tied to that issue with a logically descriptive name (see **Branch Naming** below)
 


### PR DESCRIPTION
Automated mirror of git-policies/SKILL.md from claude-skills. Generated file — do not hand-edit claude/git-policies.md.